### PR TITLE
[#175499507] Prevalidate with HMAC to fail

### DIFF
--- a/src/utils/__mocks__/saml.ts
+++ b/src/utils/__mocks__/saml.ts
@@ -107,6 +107,11 @@ interface IGetSAMLResponseParams {
 
   /** @default true */
   hasResponseSignature?: boolean;
+
+  /** @default "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" */
+  signatureMethod?:
+    | "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+    | "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
 }
 
 export const getSamlResponse: (params?: IGetSAMLResponseParams) => string = (
@@ -125,7 +130,8 @@ ${
       `<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
     <ds:SignedInfo>
         <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
-        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+        <ds:SignatureMethod Algorithm="${params.signatureMethod ||
+          "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"}"/>
         <ds:Reference URI="#_7080f453-78cb-4f57-9692-62dc8a5c23e8">
             <ds:Transforms>
                 <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>

--- a/src/utils/__tests__/saml.test.ts
+++ b/src/utils/__tests__/saml.test.ts
@@ -327,4 +327,36 @@ describe("preValidateResponse", () => {
       await asyncExpectOnCallback(mockCallback);
     });
   });
+
+  it("should preValidate fail when saml Response uses HMAC as signature algorithm", async () => {
+    mockGetXmlFromSamlResponse.mockImplementation(() =>
+      tryCatch(() =>
+        new DOMParser().parseFromString(
+          getSamlResponse({
+            signatureMethod: "http://www.w3.org/2000/09/xmldsig#hmac-sha1"
+          })
+        )
+      )
+    );
+    const strictValidationOption: StrictResponseValidationOptions = {
+      mockTestIdpIssuer: true
+    };
+    getPreValidateResponse(strictValidationOption, mockEventTracker)(
+      { ...samlConfig, acceptedClockSkewMs: 0 },
+      mockBody,
+      mockRedisCacheProvider,
+      undefined,
+      mockCallback
+    );
+    expect(mockGetXmlFromSamlResponse).toBeCalledWith(mockBody);
+    const expectedError = new Error("HMAC Signature is forbidden");
+    await asyncExpectOnCallback(mockCallback, expectedError);
+    expect(mockEventTracker).toBeCalledWith({
+      data: {
+        message: expectedError.message
+      },
+      name: expectedGenericEventName,
+      type: "ERROR"
+    });
+  });
 });

--- a/src/utils/saml.ts
+++ b/src/utils/saml.ts
@@ -65,6 +65,7 @@ interface IEntrypointCerts {
 export const SAML_NAMESPACE = {
   ASSERTION: "urn:oasis:names:tc:SAML:2.0:assertion",
   PROTOCOL: "urn:oasis:names:tc:SAML:2.0:protocol",
+  SIGNATURE: "http://www.w3.org/2000/09/xmldsig#",
   XMLDSIG: "http://www.w3.org/2000/09/xmldsig#"
 };
 
@@ -1078,6 +1079,19 @@ export const getPreValidateResponse = (
               "EncryptedAssertion"
             ).length === 0,
           _ => new Error("EncryptedAssertion element is forbidden")
+        )
+      )
+      .chain(
+        fromPredicate(
+          predicate =>
+            predicate.Response.getElementsByTagNameNS(
+              SAML_NAMESPACE.SIGNATURE,
+              "SignatureMethod"
+            )
+              .item(0)
+              ?.getAttribute("Algorithm")
+              ?.valueOf() !== "http://www.w3.org/2000/09/xmldsig#hmac-sha1",
+          _ => new Error("HMAC Signature is forbidden")
         )
       )
       .chain(

--- a/src/utils/saml.ts
+++ b/src/utils/saml.ts
@@ -65,7 +65,6 @@ interface IEntrypointCerts {
 export const SAML_NAMESPACE = {
   ASSERTION: "urn:oasis:names:tc:SAML:2.0:assertion",
   PROTOCOL: "urn:oasis:names:tc:SAML:2.0:protocol",
-  SIGNATURE: "http://www.w3.org/2000/09/xmldsig#",
   XMLDSIG: "http://www.w3.org/2000/09/xmldsig#"
 };
 
@@ -1085,7 +1084,7 @@ export const getPreValidateResponse = (
         fromPredicate(
           predicate =>
             predicate.Response.getElementsByTagNameNS(
-              SAML_NAMESPACE.SIGNATURE,
+              SAML_NAMESPACE.XMLDSIG,
               "SignatureMethod"
             )
               .item(0)


### PR DESCRIPTION
With this PR we introduced an extra step of validation in incoming SAML assertions that invalidates request when they are signed using `hmac-sha1` algo.