### PR TITLE
Add missing files in npm bundle

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -105,7 +105,7 @@ stages:
                 LICENSE
                 CHANGELOG.md
                 package.json
-                dist/*
+                dist/**
             displayName: 'Copy bundle files'
           
           - publish: $(System.DefaultWorkingDirectory)/bundle


### PR DESCRIPTION
Into the npm package, all `dist` subfolder was missing.