### PR TITLE
Add transform check + tests

### DIFF
--- a/src/utils/__mocks__/saml.ts
+++ b/src/utils/__mocks__/saml.ts
@@ -2,9 +2,12 @@ type SignatureMethod =
   | "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
   | "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
 
+export const transforms = `<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>`;
+
 export const getSamlAssertion = (
   clockSkewMs: number = 0,
-  signatureMethod: SignatureMethod = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+  signatureMethod: SignatureMethod = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+  repeatTransforms?: number
 ) => `<saml:Assertion ID="_43568006-96d4-4dcc-84da-d98e01ea3a28" IssueInstant="${new Date(
   Date.now() + clockSkewMs
 ).toISOString()}" Version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -17,8 +20,11 @@ export const getSamlAssertion = (
                 <ds:SignatureMethod Algorithm="${signatureMethod}"/>
                 <ds:Reference URI="#_43568006-96d4-4dcc-84da-d98e01ea3a28">
                     <ds:Transforms>
-                        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-                        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                    ${
+                      repeatTransforms
+                        ? transforms.repeat(repeatTransforms)
+                        : transforms
+                    }
                     </ds:Transforms>
                     <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
                     <ds:DigestValue>
@@ -115,6 +121,8 @@ interface IGetSAMLResponseParams {
 
   /** @default "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" */
   signatureMethod?: SignatureMethod;
+
+  repeatTransforms?: number;
 }
 
 export const getSamlResponse: (params?: IGetSAMLResponseParams) => string = (
@@ -137,8 +145,11 @@ ${
           "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"}"/>
         <ds:Reference URI="#_7080f453-78cb-4f57-9692-62dc8a5c23e8">
             <ds:Transforms>
-                <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-                <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                ${
+                  params.repeatTransforms
+                    ? transforms.repeat(params.repeatTransforms)
+                    : transforms
+                }
             </ds:Transforms>
             <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
             <ds:DigestValue>

--- a/src/utils/__tests__/saml.test.ts
+++ b/src/utils/__tests__/saml.test.ts
@@ -231,7 +231,7 @@ describe("preValidateResponse", () => {
     );
     const expectedError = TransformError.encode({
       errorMessage: "Transform element cannot occurs more than 4 times",
-      idpIssuer: "http://localhost:8080",
+      idpIssuer: mockTestIdpIssuer,
       numberOfTransforms: 6
     });
     expect(mockGetXmlFromSamlResponse).toBeCalledWith(mockBody);
@@ -266,7 +266,7 @@ describe("preValidateResponse", () => {
     );
     const expectedError = TransformError.encode({
       errorMessage: "Transform element cannot occurs more than 4 times",
-      idpIssuer: "http://localhost:8080",
+      idpIssuer: mockTestIdpIssuer,
       numberOfTransforms: 6
     });
     expect(mockGetXmlFromSamlResponse).toBeCalledWith(mockBody);

--- a/src/utils/__tests__/saml.test.ts
+++ b/src/utils/__tests__/saml.test.ts
@@ -222,7 +222,7 @@ describe("preValidateResponse", () => {
       mockCallback
     );
     const expectedError = new Error(
-      "Transform cannot occurs more than 4 occurrences"
+      "Transform element cannot occurs more than 4 times"
     );
     expect(mockGetXmlFromSamlResponse).toBeCalledWith(mockBody);
     await asyncExpectOnCallback(mockCallback, expectedError);
@@ -253,7 +253,7 @@ describe("preValidateResponse", () => {
       mockCallback
     );
     const expectedError = new Error(
-      "Transform cannot occurs more than 4 occurrences"
+      "Transform element cannot occurs more than 4 times"
     );
     expect(mockGetXmlFromSamlResponse).toBeCalledWith(mockBody);
     await asyncExpectOnCallback(mockCallback, expectedError);

--- a/src/utils/__tests__/saml.test.ts
+++ b/src/utils/__tests__/saml.test.ts
@@ -197,7 +197,7 @@ describe("preValidateResponse", () => {
     });
   });
 
-  it("should preValidate fail when saml Assertion has more than 4 Transform elements in SignedInfo", async () => {
+  it("should preValidate fail when saml response has more than 4 Transform (4 Assertion + 2 Response) elements in SignedInfo", async () => {
     mockGetXmlFromSamlResponse.mockImplementationOnce(() =>
       tryCatch(() =>
         new DOMParser().parseFromString(

--- a/src/utils/__tests__/saml.test.ts
+++ b/src/utils/__tests__/saml.test.ts
@@ -197,7 +197,7 @@ describe("preValidateResponse", () => {
     });
   });
 
-  it("should preValidate fail when saml Assertion has more than 2 Transforms elements in SignedInfo", async () => {
+  it("should preValidate fail when saml Assertion has more than 4 Transform elements in SignedInfo", async () => {
     mockGetXmlFromSamlResponse.mockImplementationOnce(() =>
       tryCatch(() =>
         new DOMParser().parseFromString(
@@ -222,7 +222,7 @@ describe("preValidateResponse", () => {
       mockCallback
     );
     const expectedError = new Error(
-      "Transforms cannot contain more than 2 children elements"
+      "Transform cannot occurs more than 4 occurrences"
     );
     expect(mockGetXmlFromSamlResponse).toBeCalledWith(mockBody);
     await asyncExpectOnCallback(mockCallback, expectedError);
@@ -234,7 +234,7 @@ describe("preValidateResponse", () => {
       type: "ERROR"
     });
   });
-  it("should preValidate fail when saml Response has more than 2 Transforms elements in SignedInfo", async () => {
+  it("should preValidate fail when saml Response has more than 4 Transforms elements in SignedInfo", async () => {
     mockGetXmlFromSamlResponse.mockImplementationOnce(() =>
       tryCatch(() =>
         new DOMParser().parseFromString(
@@ -253,7 +253,7 @@ describe("preValidateResponse", () => {
       mockCallback
     );
     const expectedError = new Error(
-      "Transforms cannot contain more than 2 children elements"
+      "Transform cannot occurs more than 4 occurrences"
     );
     expect(mockGetXmlFromSamlResponse).toBeCalledWith(mockBody);
     await asyncExpectOnCallback(mockCallback, expectedError);

--- a/src/utils/__tests__/saml.test.ts
+++ b/src/utils/__tests__/saml.test.ts
@@ -234,7 +234,7 @@ describe("preValidateResponse", () => {
       type: "ERROR"
     });
   });
-  it("should preValidate fail when saml Response has more than 4 Transforms elements in SignedInfo", async () => {
+  it("should preValidate fail when saml response has more than 4 Transform elements (4 Response + 2 Assertion) in SignedInfo", async () => {
     mockGetXmlFromSamlResponse.mockImplementationOnce(() =>
       tryCatch(() =>
         new DOMParser().parseFromString(

--- a/src/utils/saml.ts
+++ b/src/utils/saml.ts
@@ -1390,21 +1390,21 @@ export const getPreValidateResponse = (
     .bimap(
       error => {
         if (eventHandler) {
-          error instanceof Error
+          TransformError.is(error)
             ? eventHandler({
-                data: {
-                  message: error.message
-                },
-                name: "spid.error.generic",
-                type: "ERROR"
-              })
-            : eventHandler({
                 data: {
                   idpIssuer: error.idpIssuer,
                   message: error.errorMessage,
                   numberOfTransforms: String(error.numberOfTransforms)
                 },
                 name: "spid.error.transformOccurenceOverflow",
+                type: "ERROR"
+              })
+            : eventHandler({
+                data: {
+                  message: error.message
+                },
+                name: "spid.error.generic",
                 type: "ERROR"
               });
         }

--- a/src/utils/saml.ts
+++ b/src/utils/saml.ts
@@ -605,7 +605,7 @@ const transformsValidation = (
     transformElements =>
       fromPredicate(
         (_: readonly Element[]) => !isOverflowNumberOf(_, 4),
-        () => new Error("Transform cannot occurs more than 4 occurrences")
+        () => new Error("Transform element cannot occurs more than 4 times")
       )(transformElements).map(() => targetElement)
   );
 };

--- a/src/utils/saml.ts
+++ b/src/utils/saml.ts
@@ -588,7 +588,7 @@ const isOverflowNumberOfChildren = (
   maxNumberOfChildren: number
 ): boolean => {
   // tslint:disable-next-line: readonly-array
-  const elemArray = Array.from(element.childNodes).map(_ => _);
+  const elemArray = Array.from(element.childNodes);
   return (
     elemArray.filter(e => e.nodeType === e.ELEMENT_NODE).length >
     maxNumberOfChildren

--- a/src/utils/saml.ts
+++ b/src/utils/saml.ts
@@ -30,16 +30,11 @@ import { collect, lookup } from "fp-ts/lib/Record";
 import { setoidString } from "fp-ts/lib/Setoid";
 import {
   fromEither as fromEitherToTaskEither,
-  fromLeft,
   TaskEither,
   tryCatch
 } from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { UTCISODateFromString } from "italia-ts-commons/lib/dates";
-import {
-  NonNegativeInteger,
-  NonNegativeNumber
-} from "italia-ts-commons/lib/numbers";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { pki } from "node-forge";
 import { SamlConfig } from "passport-saml";
@@ -605,7 +600,7 @@ export type TransformError = t.TypeOf<typeof TransformError>;
 
 const transformsValidation = (
   targetElement: Element,
-  idpIssuer: NonEmptyString
+  idpIssuer: string
 ): Either<TransformError, Element> => {
   return fromPredicateOption(
     (elements: readonly Element[]) => elements.length > 0
@@ -1389,10 +1384,7 @@ export const getPreValidateResponse = (
     // check for Transform over SAML Response
     .chain(_ =>
       fromEitherToTaskEither(
-        transformsValidation(
-          _.Response,
-          _.SAMLRequestCache.idpIssuer as NonEmptyString
-        )
+        transformsValidation(_.Response, _.SAMLRequestCache.idpIssuer)
       ).map(() => _)
     )
     .bimap(


### PR DESCRIPTION
This PR enables check on `<ds:Transform>` occurrences number, in order to avoid parsing unexpected SAML Response and Assertion.