### PR TITLE
[fix] New spid attributes for dev testing

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -71,13 +71,7 @@ const serviceProviderConfig: IServiceProviderConfig = {
   },
   publicCert: fs.readFileSync("./certs/cert.pem", "utf-8"),
   requiredAttributes: {
-    attributes: [
-      "email",
-      "name",
-      "familyName",
-      "fiscalNumber",
-      "dateOfBirth"
-    ],
+    attributes: ["email", "name", "familyName", "fiscalNumber", "dateOfBirth"],
     name: "Required attrs"
   },
   spidCieUrl:

--- a/src/example.ts
+++ b/src/example.ts
@@ -72,12 +72,11 @@ const serviceProviderConfig: IServiceProviderConfig = {
   publicCert: fs.readFileSync("./certs/cert.pem", "utf-8"),
   requiredAttributes: {
     attributes: [
-      "address",
       "email",
       "name",
       "familyName",
       "fiscalNumber",
-      "mobilePhone"
+      "dateOfBirth"
     ],
     name: "Required attrs"
   },


### PR DESCRIPTION
Backend now expect dateOfBirth, but no phone and address.
Dev testing with mock needs a metadata compliant to these changes.