### PR TITLE
[#IC-241] Fixed bad parameter passed to SpidStrategy constructor

### DIFF
--- a/src/utils/middleware.ts
+++ b/src/utils/middleware.ts
@@ -254,7 +254,7 @@ export const makeSpidStrategy = (
   // eslint-disable-next-line max-params
 ): SpidStrategy =>
   new SpidStrategy(
-    { ...options, passReqToCallback: true },
+    { ...options.sp, passReqToCallback: true },
     getSamlOptions,
     (_: express.Request, profile: Profile, done: VerifiedCallback) => {
       // at this point SAML authentication is successful


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Passed `...options.sp` to SpidStrategy constructor instead of `...options`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The options parameter passed to the SpidStrategy constructor does not contain the SamlOptions required, which are indeed inside the sp property. 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
All the tests run fine

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
