### PR TITLE
[#HSL-7] Support spid-saml-check

### DIFF
--- a/src/utils/middleware.ts
+++ b/src/utils/middleware.ts
@@ -76,6 +76,7 @@ export interface IServiceProviderConfig {
   spidCieUrl?: string;
   spidTestEnvUrl?: string;
   spidValidatorUrl?: string;
+  spidSamlCheckUrl?: string;
   IDPMetadataUrl: string;
   organization: IServiceProviderOrganization;
   contacts?: ReadonlyArray<ContactPerson>;
@@ -187,6 +188,21 @@ export const getSpidStrategyOptionsUpdater = (
                 `${serviceProviderConfig.spidTestEnvUrl}/metadata`,
                 {
                   [serviceProviderConfig.spidTestEnvUrl]: "xx_testenv2"
+                }
+              ),
+              TE.getOrElseW(() => T.of({}))
+            )
+          ]
+        : []
+    )
+    .concat(
+      NonEmptyString.is(serviceProviderConfig.spidSamlCheckUrl)
+        ? [
+            pipe(
+              fetchIdpsMetadata(
+                `${serviceProviderConfig.spidSamlCheckUrl}/metadata.xml`,
+                {
+                  [serviceProviderConfig.spidSamlCheckUrl]: "xx_samlcheck"
                 }
               ),
               TE.getOrElseW(() => T.of({}))


### PR DESCRIPTION
Introduce support for [`spid-saml-check`](https://github.com/italia/spid-saml-check) as fake IDP for testing and development. `spid-saml-check` should be preferred to `spid-testenv2` as the latter is now deprecated. 

* Add spid-saml-check IDP ([here](https://github.com/pagopa/io-spid-commons/commit/9a88e67d0a330abcce9857fc0726e2695c1a95ad))
* Refactor ([here](https://github.com/pagopa/io-spid-commons/commit/d1ef8b7e02f07e85f230f9aed24b8a2782e819fa))