### PR TITLE
[POC] Pass `login` request data to `acs`

### DIFF
--- a/src/@types/passport-saml/index.d.ts
+++ b/src/@types/passport-saml/index.d.ts
@@ -1,7 +1,7 @@
 import {
   SamlConfig,
   VerifyWithRequest,
-  VerifyWithoutRequest
+  VerifyWithoutRequest,
 } from "passport-saml";
 
 import * as express from "express";
@@ -13,7 +13,7 @@ declare module "passport-saml" {
 
     validatePostResponse(
       body: { SAMLResponse: string },
-      callback: (err: Error, profile?: unknown, loggedOut?: boolean) => void
+      callback: (err: Error, profile?: object, loggedOut?: boolean) => void
     ): void;
 
     generateAuthorizeRequest(

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -9,7 +9,7 @@ import {
   IApplicationConfig,
   IServiceProviderConfig,
   SamlConfig,
-  withSpid
+  withSpid,
 } from "../";
 import { IDPEntityDescriptor } from "../types/IDPEntityDescriptor";
 import * as metadata from "../utils/metadata";
@@ -19,8 +19,9 @@ import {
   mockCIEIdpMetadata,
   mockCIETestIdpMetadata,
   mockIdpMetadata,
-  mockTestenvIdpMetadata
+  mockTestenvIdpMetadata,
 } from "../__mocks__/metadata";
+import * as t from "io-ts";
 
 const mockFetchIdpsMetadata = jest.spyOn(metadata, "fetchIdpsMetadata");
 
@@ -100,7 +101,7 @@ const appConfig: IApplicationConfig = {
   loginPath: expectedLoginPath,
   metadataPath,
   sloPath: expectedSloPath,
-  spidLevelsWhitelist: ["SpidL2", "SpidL3"]
+  spidLevelsWhitelist: ["SpidL2", "SpidL3"],
 };
 
 const samlConfig: SamlConfig = {
@@ -114,7 +115,7 @@ const samlConfig: SamlConfig = {
   issuer: "https://spid.agid.gov.it/cd",
   logoutCallbackUrl: "http://localhost:3000/slo",
   privateCert: samlKey,
-  validateInResponseTo: true
+  validateInResponseTo: true,
 };
 
 const serviceProviderConfig: IServiceProviderConfig = {
@@ -122,7 +123,7 @@ const serviceProviderConfig: IServiceProviderConfig = {
   organization: {
     URL: "https://example.com",
     displayName: "Organization display name",
-    name: "Organization name"
+    name: "Organization name",
   },
   publicCert: samlCert,
   requiredAttributes: {
@@ -132,16 +133,16 @@ const serviceProviderConfig: IServiceProviderConfig = {
       "name",
       "familyName",
       "fiscalNumber",
-      "mobilePhone"
+      "mobilePhone",
     ],
-    name: "Required attrs"
+    name: "Required attrs",
   },
   spidCieUrl,
   spidCieTestUrl,
   spidTestEnvUrl,
   strictResponseValidation: {
-    "http://localhost:8080": true
-  }
+    "http://localhost:8080": true,
+  },
 };
 
 const mockRedisClient = {} as RedisClientType;
@@ -186,7 +187,9 @@ describe("io-spid-commons withSpid", () => {
       acs: async () =>
         ResponsePermanentRedirect({ href: "/success?acs" } as ValidUrl),
       logout: async () =>
-        ResponsePermanentRedirect({ href: "/success?logout" } as ValidUrl)
+        ResponsePermanentRedirect({ href: "/success?logout" } as ValidUrl),
+      additionalPropsCodec: t.type({ test: t.number }),
+      requestToAdditionalProps: (req) => ({ test: 1 }),
     })();
     expect(mockFetchIdpsMetadata).toBeCalledTimes(4);
     const emptySpidStrategyOption = getSpidStrategyOption(spid.app);
@@ -221,7 +224,7 @@ describe("io-spid-commons withSpid", () => {
       ...mockIdpMetadata,
       ...mockCIEIdpMetadata,
       ...mockCIETestIdpMetadata,
-      ...mockTestenvIdpMetadata
+      ...mockTestenvIdpMetadata,
     });
   });
   it("should reject blacklisted spid levels", async () => {
@@ -236,7 +239,9 @@ describe("io-spid-commons withSpid", () => {
       acs: async () =>
         ResponsePermanentRedirect({ href: "/success?acs" } as ValidUrl),
       logout: async () =>
-        ResponsePermanentRedirect({ href: "/success?logout" } as ValidUrl)
+        ResponsePermanentRedirect({ href: "/success?logout" } as ValidUrl),
+      additionalPropsCodec: t.type({ test: t.number }),
+      requestToAdditionalProps: (req) => ({ test: 1 }),
     })();
     return request(spid.app)
       .get(`${appConfig.loginPath}?authLevel=SpidL1`)

--- a/src/example.ts
+++ b/src/example.ts
@@ -183,6 +183,10 @@ pipe(
       redisClient,
       samlConfig,
       serviceProviderConfig,
+
+      // eslint-disable-next-line sort-keys
+      additionalPropsCodec: t.type({ test: t.number }),
+      requestToAdditionalProps: (_req) => ({ test: 1 }),
     })
   ),
   T.map(({ app: withSpidApp, idpMetadataRefresher }) => {

--- a/src/strategy/__tests__/spid.test.ts
+++ b/src/strategy/__tests__/spid.test.ts
@@ -1,11 +1,15 @@
 import { RedisClientType } from "@redis/client";
 import * as express from "express";
+import * as t from "io-ts";
 import { Profile, VerifiedCallback } from "passport-saml";
 import { getSamlOptions } from "../../utils/saml";
 import * as redisCacheProvider from "../redis_cache_provider";
 import { SpidStrategy } from "../spid";
 
-const mockRedisClient = {} as RedisClientType;
+const mockExtendedRedisCacheProvider = {} as RedisClientType;
+
+const additionalPropsCodec = t.type({});
+const requestToAdditionalProps = (req: express.Request) => ({});
 
 describe("SamlStrategy prototype arguments check", () => {
   let OriginalPassportSaml: any;
@@ -34,7 +38,7 @@ describe("SamlStrategy#constructor", () => {
       },
       save: () => {
         return;
-      }
+      },
     };
     const mockNoopCacheProvider = jest
       .spyOn(redisCacheProvider, "noopCacheProvider")
@@ -47,12 +51,8 @@ describe("SamlStrategy#constructor", () => {
         // `done` is a passport callback that signals success
         done(null, profile);
       },
-      mockRedisClient as any
-    );
-
-    expect(spidStrategy["options"]).toHaveProperty(
-      "requestIdExpirationPeriodMs",
-      900000
+      mockExtendedRedisCacheProvider as any,
+      requestToAdditionalProps
     );
 
     expect(spidStrategy["options"]).toHaveProperty(
@@ -60,8 +60,6 @@ describe("SamlStrategy#constructor", () => {
       expectedNoopCacheProvider
     );
     expect(mockNoopCacheProvider).toBeCalledTimes(1);
-
-    expect(spidStrategy["extendedRedisCacheProvider"]).toBeTruthy();
   });
 });
 

--- a/src/strategy/spid.ts
+++ b/src/strategy/spid.ts
@@ -9,16 +9,13 @@ import {
   VerifyWithRequest,
 } from "passport-saml";
 import { Strategy as SamlStrategy } from "passport-saml";
-import { RedisClientType, RedisClusterType } from "redis";
 
 import { MultiSamlConfig } from "passport-saml/multiSamlStrategy";
 
-import { Second } from "@pagopa/ts-commons/lib/units";
 import { pipe } from "fp-ts/lib/function";
 import { DoneCallbackT } from "..";
 import { ILollipopParams } from "../types/lollipop";
 import {
-  getExtendedRedisCacheProvider,
   IExtendedCacheProvider,
   noopCacheProvider,
 } from "./redis_cache_provider";
@@ -35,10 +32,10 @@ export type PreValidateResponseDoneCallbackT = (
   response: string
 ) => void;
 
-export type PreValidateResponseT = (
+export type PreValidateResponseT = <T extends Record<string, unknown>>(
   samlConfig: SamlConfig,
   body: unknown,
-  extendedRedisCacheProvider: IExtendedCacheProvider,
+  extendedRedisCacheProvider: IExtendedCacheProvider<T>,
   doneCb: PreValidateResponseDoneCallbackT | undefined,
 
   callback: (
@@ -49,31 +46,22 @@ export type PreValidateResponseT = (
   ) => void
 ) => void;
 
-export class SpidStrategy extends SamlStrategy {
-  private readonly extendedRedisCacheProvider: IExtendedCacheProvider;
-
+export class SpidStrategy<
+  T extends Record<string, unknown>
+> extends SamlStrategy {
   // eslint-disable-next-line max-params
   constructor(
     private readonly options: SamlConfig,
     private readonly getSamlOptions: MultiSamlConfig["getSamlOptions"],
     verify: VerifyWithRequest | VerifyWithoutRequest,
-    private readonly redisClient: RedisClientType | RedisClusterType,
+    private readonly extendedRedisCacheProvider: IExtendedCacheProvider<T>,
+    private readonly requestToAdditionalProps: (req: express.Request) => T,
     private readonly tamperAuthorizeRequest?: XmlAuthorizeTamperer,
     private readonly tamperMetadata?: XmlTamperer,
     private readonly preValidateResponse?: PreValidateResponseT,
     private readonly doneCb?: DoneCallbackT
   ) {
     super(options, verify);
-    if (!options.requestIdExpirationPeriodMs) {
-      // 15 minutes
-      options.requestIdExpirationPeriodMs = 15 * 60 * 1000;
-    }
-
-    // use our custom cache provider
-    this.extendedRedisCacheProvider = getExtendedRedisCacheProvider(
-      this.redisClient,
-      Math.floor(options.requestIdExpirationPeriodMs / 1000) as Second
-    );
 
     // bypass passport-saml cache provider
     options.cacheProvider = noopCacheProvider();
@@ -93,6 +81,7 @@ export class SpidStrategy extends SamlStrategy {
           ...samlOptions,
         },
         this.extendedRedisCacheProvider,
+        this.requestToAdditionalProps,
         this.tamperAuthorizeRequest,
         this.preValidateResponse,
         (...args) => (this.doneCb ? this.doneCb(req.ip, ...args) : undefined)
@@ -123,7 +112,8 @@ export class SpidStrategy extends SamlStrategy {
           ...this.options,
           ...samlOptions,
         },
-        this.extendedRedisCacheProvider
+        this.extendedRedisCacheProvider,
+        this.requestToAdditionalProps
       );
       // we clone the original strategy to avoid race conditions
       // see https://github.com/bergie/passport-saml/pull/426/files
@@ -153,7 +143,8 @@ export class SpidStrategy extends SamlStrategy {
           ...this.options,
           ...samlOptions,
         },
-        this.extendedRedisCacheProvider
+        this.extendedRedisCacheProvider,
+        this.requestToAdditionalProps
       );
 
       // we clone the original strategy to avoid race conditions


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This PR is intended as a POC to verify the possibility of saving important data read from login request, and then retrieve it and pass it to the acs callback. 
This is done by storing them along with `SAMLRequestCacheItem` data within redis cache.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
