### PR TITLE
[#IOPID-328] Store extra parameter on login step

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,56 @@ Beware that any changes to the method signatures of
 That's why the version of passport-saml in package.json is currently fixed at
 `1.3.5`.
 
+## Store Additional data between login and acs steps
+
+If you need to pass additional parameters from login request to acs callback,
+you can use built-in additional parameter management, by adding a new `extraLoginRequestParamConfig` block in configuration:
+
+```typescript
+
+export type ExtraParamsT = t.TypeOf<typeof ExtraParams>;
+export const ExtraParams = t.type({ test: t.string });
+
+const appConfig: IApplicationConfig<ExtraParamsT> = {
+
+  extraLoginRequestParamConfig: {
+    codec: ExtraParams,
+    requestMapper: (req) =>  
+                    ExtraParams.decode({
+                                        loginType: req.header("x-test-header"),
+                                      })
+  },
+
+  assertionConsumerServicePath: "/acs",
+  clientErrorRedirectionUrl: "/error",
+  clientLoginRedirectionUrl: "/success",
+  loginPath: "/login",
+  metadataPath: "/metadata",
+  sloPath: "/logout",
+  spidLevelsWhitelist: ["SpidL2", "SpidL3"],
+};
+```
+
+The acs callback will receive a second parameter, containing the information extracted during login step for the user:
+
+```typescript
+
+const acs: AssertionConsumerServiceT<ExtraParamsT> = async (
+  payload,
+  extraParams
+  // ^^^ 
+  // ExtraParamsT | undefined
+) => {
+  logger.info("acs:%s%s", JSON.stringify(payload), JSON.stringify(extraParams));
+  return ResponsePermanentRedirect({ href: "/success?acs" } as ValidUrl);
+};
+```
+
+NOTE:   If the mapper or the coded return a validation error, `extraParams` will be undefined.
+NOTE 2: It's better to define the codec with defaults and/or partial properties, to avoid undefined values during deploy phase
+        (ie: Data stored before the deploy that cannot be decoded with new codec because of lack of required properties)
+
+
 ## Local development
 
 To run the project locally with the embedded example express application run the following commands:

--- a/src/__mocks__/extraParams.ts
+++ b/src/__mocks__/extraParams.ts
@@ -1,0 +1,10 @@
+import * as t from "io-ts";
+
+export const expectedExtraParams = {
+  aNewParam: "a new param",
+  anotherParam: 2,
+};
+export const expectedExtraParamsC = t.type({
+  aNewParam: t.string,
+  anotherParam: t.number,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export interface IExtraLoginRequestParamConfig<
 > {
   // The codec to decode extra params from Redis cache provider
   readonly codec: t.Type<T>;
-  // Extracts extra params from Login Request, that will be forwarded to the acs controller
+  // Extracts extra params from Login Request, that if valid will be forwarded to the acs controller
   readonly requestMapper: (req: express.Request) => t.Validation<T>;
 }
 
@@ -163,7 +163,6 @@ export const withSpidAuthMiddleware =
         return res.redirect(clientLoginRedirectionUrl);
       }
 
-      //
       const { extraLoginRequestParams, ...userBaseProps } = user as Record<
         "extraLoginRequestParams",
         undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import * as passport from "passport";
 import { SamlConfig } from "passport-saml";
 import { RedisClientType, RedisClusterType } from "redis";
 import { Builder } from "xml2js";
+import * as E from "fp-ts/Either";
 import { SPID_LEVELS } from "./config";
 import { noopCacheProvider } from "./strategy/redis_cache_provider";
 import { logger } from "./utils/logger";
@@ -48,8 +49,9 @@ import {
 import { getMetadataTamperer } from "./utils/saml";
 
 // assertion consumer service express handler
-export type AssertionConsumerServiceT = (
-  userPayload: unknown
+export type AssertionConsumerServiceT<T extends Record<string, unknown>> = (
+  userPayload: unknown,
+  extraLoginRequestParams?: T
 ) => Promise<
   | IResponseErrorInternal
   | IResponseErrorValidation
@@ -79,8 +81,24 @@ export interface IEventInfo {
 
 export type EventTracker = (params: IEventInfo) => void;
 
+export interface IExtraLoginRequestParamConfig<
+  T extends Record<string, unknown>
+> {
+  // The codec to decode extra params from Redis cache provider
+  readonly codec: t.Type<T>;
+  // Extracts extra params from Login Request, that will be forwarded to the acs controller
+  readonly requestMapper: (req: express.Request) => t.Validation<T>;
+}
+
 // express endpoints configuration
-export interface IApplicationConfig {
+export interface IApplicationConfig<
+  T extends Record<string, unknown> | undefined = undefined,
+  R = T extends Record<string, unknown>
+    ? IExtraLoginRequestParamConfig<T>
+    : T extends undefined
+    ? undefined
+    : never
+> {
   readonly assertionConsumerServicePath: string;
   readonly clientErrorRedirectionUrl: string;
   readonly clientLoginRedirectionUrl: string;
@@ -91,6 +109,7 @@ export interface IApplicationConfig {
   readonly startupIdpsMetadata?: Record<string, string>;
   readonly eventTraker?: EventTracker;
   readonly hasClockSkewLoggingEvent?: boolean;
+  readonly extraLoginRequestParamConfig?: R;
 }
 
 // re-export
@@ -101,10 +120,11 @@ export { noopCacheProvider, IServiceProviderConfig, SamlConfig };
  * with SPID authentication and redirects.
  */
 const withSpidAuthMiddleware =
-  (
-    acs: AssertionConsumerServiceT,
+  <T extends Record<string, unknown>>(
+    acs: AssertionConsumerServiceT<T>,
     clientLoginRedirectionUrl: string,
-    clientErrorRedirectionUrl: string
+    clientErrorRedirectionUrl: string,
+    extraRequestParamsCodec?: t.Type<T>
   ) =>
   (
     req: express.Request,
@@ -142,7 +162,21 @@ const withSpidAuthMiddleware =
         );
         return res.redirect(clientLoginRedirectionUrl);
       }
-      const response = await acs(user);
+
+      // TODO
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { extraLoginRequestParams, ...userBaseProps } = user as any;
+
+      const response = await acs(
+        userBaseProps,
+        pipe(
+          extraRequestParamsCodec,
+          E.fromNullable(undefined),
+          E.chainW((codec) => codec.decode(extraLoginRequestParams)),
+          E.getOrElseW(() => undefined)
+        )
+      );
+
       response.apply(res);
     })(req, res, next);
   };
@@ -152,13 +186,13 @@ type ExpressMiddleware = (
   res: express.Response,
   next: express.NextFunction
 ) => void;
-interface IWithSpidT {
-  readonly appConfig: IApplicationConfig;
+interface IWithSpidT<T extends Record<string, unknown>> {
+  readonly appConfig: IApplicationConfig<T>;
   readonly samlConfig: SamlConfig;
   readonly serviceProviderConfig: IServiceProviderConfig;
   readonly redisClient: RedisClientType | RedisClusterType;
   readonly app: express.Express;
-  readonly acs: AssertionConsumerServiceT;
+  readonly acs: AssertionConsumerServiceT<T>;
   readonly logout: LogoutT;
   readonly doneCb?: DoneCallbackT;
   readonly lollipopMiddleware?: ExpressMiddleware;
@@ -169,7 +203,7 @@ interface IWithSpidT {
  * to an express application.
  */
 // eslint-disable-next-line max-params
-export const withSpid = ({
+export const withSpid = <T extends Record<string, unknown>>({
   acs,
   app,
   appConfig,
@@ -179,7 +213,7 @@ export const withSpid = ({
   samlConfig,
   serviceProviderConfig,
   lollipopMiddleware = (_, __, next): void => next(),
-}: IWithSpidT): T.Task<{
+}: IWithSpidT<T>): T.Task<{
   readonly app: express.Express;
   readonly idpMetadataRefresher: () => T.Task<void>;
 }> => {
@@ -230,7 +264,8 @@ export const withSpid = ({
           appConfig.eventTraker,
           appConfig.hasClockSkewLoggingEvent
         ),
-        doneCb
+        doneCb,
+        appConfig.extraLoginRequestParamConfig
       );
     }),
     T.map((spidStrategy) => {
@@ -331,7 +366,9 @@ export const withSpid = ({
           withSpidAuthMiddleware(
             acs,
             appConfig.clientLoginRedirectionUrl,
-            appConfig.clientErrorRedirectionUrl
+            appConfig.clientErrorRedirectionUrl,
+            // TODO
+            appConfig.extraLoginRequestParamConfig?.codec as t.Type<T>
           )
         )
       );

--- a/src/strategy/__tests__/redis_cache_provider.test.ts
+++ b/src/strategy/__tests__/redis_cache_provider.test.ts
@@ -1,4 +1,3 @@
-import * as t from "io-ts";
 import { RedisClientType, RedisClusterType } from "@redis/client";
 import { isLeft, isRight } from "fp-ts/lib/Either";
 import { SamlConfig } from "passport-saml";
@@ -7,6 +6,10 @@ import {
   noopCacheProvider,
   SAMLRequestCacheItem,
 } from "../redis_cache_provider";
+import {
+  expectedExtraParams,
+  expectedExtraParamsC,
+} from "../../__mocks__/extraParams";
 
 const mockSetEx = jest.fn();
 const mockGet = jest.fn();
@@ -32,12 +35,6 @@ NameQualifier="https://spid.agid.gov.it/cd" Format="urn:oasis:names:tc:SAML:2.0:
 <saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">https://www.spid.gov.it/SpidL2</saml:AuthnContextClassRef>
 </samlp:RequestedAuthnContext>
 </samlp:AuthnRequest>`;
-
-const expectedExtraParams = { aNewParam: "a new param", anotherParam: 2 };
-const expectedExtraParamsC = t.type({
-  aNewParam: t.string,
-  anotherParam: t.number,
-});
 
 const samlConfig: SamlConfig = {
   idpIssuer: "http://localhost:8080/",

--- a/src/strategy/__tests__/redis_cache_provider.test.ts
+++ b/src/strategy/__tests__/redis_cache_provider.test.ts
@@ -4,16 +4,15 @@ import { SamlConfig } from "passport-saml";
 import {
   getExtendedRedisCacheProvider,
   noopCacheProvider,
-  SAMLRequestCacheItem
+  SAMLRequestCacheItem,
 } from "../redis_cache_provider";
 
 const mockSet = jest.fn();
 const mockGet = jest.fn();
 const mockDel = jest.fn();
 
-const mockRedisClient:
-  | RedisClientType
-  | RedisClusterType = {} as RedisClientType;
+const mockRedisClient: RedisClientType | RedisClusterType =
+  {} as RedisClientType;
 mockRedisClient.setEx = mockSet;
 mockRedisClient.get = mockGet;
 mockRedisClient.del = mockDel;
@@ -34,7 +33,7 @@ const SAMLRequest = `<?xml version="1.0"?>
 </samlp:AuthnRequest>`;
 
 const samlConfig: SamlConfig = {
-  idpIssuer: "http://localhost:8080/"
+  idpIssuer: "http://localhost:8080/",
 };
 
 describe("noopCacheProvider", () => {
@@ -48,7 +47,7 @@ describe("noopCacheProvider", () => {
     noopCacheProvider().save(expectedKey, expectedValue, mockCallback);
     expect(mockCallback).toBeCalledWith(null, {
       createdAt: expect.any(Date),
-      value: expectedValue
+      value: expectedValue,
     });
   });
   it("should get method of noopCacheProvider do noting", () => {
@@ -72,7 +71,8 @@ describe("getExtendedRedisCacheProvider#save", () => {
     );
     const cacheSAMLResponse = await redisCacheProvider.save(
       SAMLRequest,
-      samlConfig
+      samlConfig,
+      undefined
     )();
     expect(mockSet.mock.calls[0][0]).toBe(`SAML-EXT-${expectedRequestID}`);
     expect(mockSet.mock.calls[0][1]).toBe(keyExpirationPeriodSeconds);
@@ -82,7 +82,7 @@ describe("getExtendedRedisCacheProvider#save", () => {
       expect(cacheSAMLResponse.right).toEqual({
         RequestXML: SAMLRequest,
         createdAt: expect.any(Date),
-        idpIssuer: samlConfig.idpIssuer
+        idpIssuer: samlConfig.idpIssuer,
       });
     }
   });
@@ -96,7 +96,8 @@ describe("getExtendedRedisCacheProvider#save", () => {
     );
     const cacheSAMLResponse = await redisCacheProvider.save(
       SAMLRequest,
-      samlConfig
+      samlConfig,
+      undefined
     )();
     expect(mockSet.mock.calls[0][0]).toBe(`SAML-EXT-${expectedRequestID}`);
     expect(mockSet.mock.calls[0][1]).toBe(keyExpirationPeriodSeconds);
@@ -114,7 +115,11 @@ describe("getExtendedRedisCacheProvider#save", () => {
     const redisCacheProvider = getExtendedRedisCacheProvider(
       mockRedisClient as any
     );
-    const cacheSAMLResponse = await redisCacheProvider.save(SAMLRequest, {})();
+    const cacheSAMLResponse = await redisCacheProvider.save(
+      SAMLRequest,
+      {},
+      undefined
+    )();
     expect(isRight(cacheSAMLResponse)).toBeFalsy();
     if (isLeft(cacheSAMLResponse)) {
       expect(cacheSAMLResponse.left).toEqual(
@@ -132,7 +137,8 @@ describe("getExtendedRedisCacheProvider#save", () => {
     );
     const cacheSAMLResponse = await redisCacheProvider.save(
       SAMLRequestWithoutID,
-      samlConfig
+      samlConfig,
+      undefined
     )();
     expect(isRight(cacheSAMLResponse)).toBeFalsy();
     if (isLeft(cacheSAMLResponse)) {
@@ -148,9 +154,9 @@ describe("getExtendedRedisCacheProvider#save", () => {
     const expectedRequestData: SAMLRequestCacheItem = {
       RequestXML: SAMLRequest,
       createdAt: new Date(),
-      idpIssuer: samlConfig.idpIssuer as string
+      idpIssuer: samlConfig.idpIssuer as string,
     };
-    mockGet.mockImplementation(_ =>
+    mockGet.mockImplementation((_) =>
       Promise.resolve(JSON.stringify(expectedRequestData))
     );
     const redisCacheProvider = getExtendedRedisCacheProvider(
@@ -165,7 +171,7 @@ describe("getExtendedRedisCacheProvider#save", () => {
   });
   it("should return an error if the reading process on redis fail", async () => {
     const expectedRedisError = new Error("readError");
-    mockGet.mockImplementation(_ => Promise.reject(expectedRedisError));
+    mockGet.mockImplementation((_) => Promise.reject(expectedRedisError));
     const redisCacheProvider = getExtendedRedisCacheProvider(
       mockRedisClient as any
     );
@@ -184,9 +190,9 @@ describe("getExtendedRedisCacheProvider#save", () => {
     const invalidCachedRequestData = {
       RequestXML: SAMLRequest,
       createdAt: new Date(),
-      idpIssuer: undefined
+      idpIssuer: undefined,
     };
-    mockGet.mockImplementation(_ =>
+    mockGet.mockImplementation((_) =>
       Promise.resolve(JSON.stringify(invalidCachedRequestData))
     );
     const redisCacheProvider = getExtendedRedisCacheProvider(
@@ -200,7 +206,7 @@ describe("getExtendedRedisCacheProvider#save", () => {
     }
   });
   it("should return an error if the cached Request is missing", async () => {
-    mockGet.mockImplementation(_ => Promise.resolve(null));
+    mockGet.mockImplementation((_) => Promise.resolve(null));
     const redisCacheProvider = getExtendedRedisCacheProvider(
       mockRedisClient as any
     );
@@ -215,7 +221,7 @@ describe("getExtendedRedisCacheProvider#save", () => {
 
 describe("getExtendedRedisCacheProvider#remove", () => {
   it("should return the RequestID if the deletion process succeded", async () => {
-    mockDel.mockImplementation(_ => Promise.resolve(1));
+    mockDel.mockImplementation((_) => Promise.resolve(1));
     const redisCacheProvider = getExtendedRedisCacheProvider(
       mockRedisClient as any
     );
@@ -229,7 +235,7 @@ describe("getExtendedRedisCacheProvider#remove", () => {
 
   it("should return an error if the cache's deletion fail", async () => {
     const expectedDelRedisError = new Error("delError");
-    mockDel.mockImplementation(_ => Promise.reject(expectedDelRedisError));
+    mockDel.mockImplementation((_) => Promise.reject(expectedDelRedisError));
     const redisCacheProvider = getExtendedRedisCacheProvider(
       mockRedisClient as any
     );

--- a/src/strategy/__tests__/saml_client.test.ts
+++ b/src/strategy/__tests__/saml_client.test.ts
@@ -1,4 +1,5 @@
 import * as jose from "jose";
+import * as t from "io-ts";
 import { left, right } from "fp-ts/lib/Either";
 import { fromEither } from "fp-ts/lib/TaskEither";
 import { Builder, parseStringPromise } from "xml2js";
@@ -10,14 +11,15 @@ import { getExtendedRedisCacheProvider } from "../redis_cache_provider";
 import { CustomSamlClient } from "../saml_client";
 import {
   DEFAULT_LOLLIPOP_HASH_ALGORITHM,
-  LOLLIPOP_PUB_KEY_HEADER_NAME
+  LOLLIPOP_PUB_KEY_HEADER_NAME,
 } from "../../types/lollipop";
 import { JwkPublicKey } from "@pagopa/ts-commons/lib/jwk";
 import { samlRequest, samlRequestWithID } from "../../utils/__mocks__/saml";
 import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
-import { UserAgentSemver } from "@pagopa/ts-commons/lib/http-user-agent";
+import * as E from "fp-ts/Either";
 import { RedisClientType } from "@redis/client";
+import { IExtraLoginRequestParamConfig } from "../..";
 
 const mockSet = jest.fn();
 const mockGet = jest.fn();
@@ -29,7 +31,7 @@ mockRedisClient.get = mockGet;
 mockRedisClient.del = mockDel;
 
 const redisCacheProvider = getExtendedRedisCacheProvider(
-  (mockRedisClient as unknown) as any
+  mockRedisClient as unknown as any
 );
 
 const serviceProviderConfig: IServiceProviderConfig = {
@@ -38,7 +40,7 @@ const serviceProviderConfig: IServiceProviderConfig = {
   organization: {
     URL: "https://example.com",
     displayName: "Organization display name",
-    name: "Organization name"
+    name: "Organization name",
   },
   publicCert: "",
   requiredAttributes: {
@@ -48,15 +50,15 @@ const serviceProviderConfig: IServiceProviderConfig = {
       "name",
       "familyName",
       "fiscalNumber",
-      "mobilePhone"
+      "mobilePhone",
     ],
-    name: "Required attrs"
+    name: "Required attrs",
   },
   spidCieUrl: "https://idserver.servizicie.interno.gov.it:8443/idp/shibboleth",
   spidCieTestUrl:
     "https://collaudo.idserver.servizicie.interno.gov.it/idp/shibboleth",
   spidTestEnvUrl: "https://spid-testenv2:8088",
-  spidValidatorUrl: "http://localhost:8080"
+  spidValidatorUrl: "http://localhost:8080",
 };
 const expectedRequestID = "123456";
 const SAMLRequest = `<?xml version="1.0"?>
@@ -84,7 +86,7 @@ const aJwkPubKey: JwkPublicKey = {
   kty: "EC",
   crv: "secp256k1",
   x: "Q8K81dZcC4DdKl52iW7bT0ubXXm2amN835M_v5AgpSE",
-  y: "lLsw82Q414zPWPluI5BmdKHK6XbFfinc8aRqbZCEv0A"
+  y: "lLsw82Q414zPWPluI5BmdKHK6XbFfinc8aRqbZCEv0A",
 };
 
 describe("SAML prototype arguments check", () => {
@@ -119,7 +121,8 @@ describe("CustomSamlClient#constructor", () => {
   it("should CustomSamlClient constructor call SAML constructor with overrided validateInResponseTo", () => {
     const customSamlClient = new CustomSamlClient(
       { validateInResponseTo: true },
-      redisCacheProvider
+      redisCacheProvider,
+      undefined
     );
     expect(customSamlClient).toBeTruthy();
 
@@ -138,7 +141,8 @@ describe("CustomSamlClient#validatePostResponse", () => {
   it("should validatePostResponse call SAML validatePostResponse", () => {
     const customSamlClient = new CustomSamlClient(
       { validateInResponseTo: true },
-      redisCacheProvider
+      redisCacheProvider,
+      undefined
     );
     expect(customSamlClient).toBeTruthy();
     customSamlClient.validatePostResponse({ SAMLResponse: "" }, mockedCallback);
@@ -154,6 +158,7 @@ describe("CustomSamlClient#validatePostResponse", () => {
     const customSamlClient = new CustomSamlClient(
       { validateInResponseTo: true },
       redisCacheProvider,
+      undefined,
       authReqTampener,
       mockPreValidate
     );
@@ -179,6 +184,7 @@ describe("CustomSamlClient#validatePostResponse", () => {
     const customSamlClient = new CustomSamlClient(
       { validateInResponseTo: true },
       redisCacheProvider,
+      undefined,
       authReqTampener,
       mockPreValidate
     );
@@ -202,10 +208,11 @@ describe("CustomSamlClient#validatePostResponse", () => {
       .mockImplementation((_, __, ___, ____, callback) => {
         callback(null, true, expectedAuthnRequestID);
       });
-    mockDel.mockImplementation(_ => Promise.resolve(1));
+    mockDel.mockImplementation((_) => Promise.resolve(1));
     const customSamlClient = new CustomSamlClient(
       { validateInResponseTo: true },
       redisCacheProvider,
+      undefined,
       authReqTampener,
       mockPreValidate
     );
@@ -219,7 +226,7 @@ describe("CustomSamlClient#validatePostResponse", () => {
       expect.any(Function)
     );
     // Before checking the execution of the callback we must await that the TaskEither execution is completed.
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         expect(mockDel).toBeCalledWith(`SAML-EXT-${expectedAuthnRequestID}`);
         expect(mockedCallback).toBeCalledWith(null, {}, false);
@@ -236,10 +243,11 @@ describe("CustomSamlClient#validatePostResponse", () => {
       .mockImplementation((_, __, ___, ____, callback) => {
         callback(null, true, expectedAuthnRequestID);
       });
-    mockDel.mockImplementation(_ => Promise.reject(expectedDelError));
+    mockDel.mockImplementation((_) => Promise.reject(expectedDelError));
     const customSamlClient = new CustomSamlClient(
       { validateInResponseTo: true },
       redisCacheProvider,
+      undefined,
       authReqTampener,
       mockPreValidate
     );
@@ -253,7 +261,7 @@ describe("CustomSamlClient#validatePostResponse", () => {
       expect.any(Function)
     );
     // Before checking the execution of the callback we must await that the TaskEither execution is completed.
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         expect(mockDel).toBeCalledWith(`SAML-EXT-${expectedAuthnRequestID}`);
         expect(mockedCallback).toBeCalledWith(
@@ -274,32 +282,33 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
   });
 
   const samlConfigMock = {
-    issuer: "ISSUER"
+    issuer: "ISSUER",
   } as any;
 
   const builder = new Builder({
-    xmldec: { encoding: undefined, version: "1.0" }
+    xmldec: { encoding: undefined, version: "1.0" },
   });
 
   it("should generateAuthorizeRequest call super generateAuthorizeRequest if tamperAuthorizeRequest is not provided", () => {
     const req = mockReq();
     const expectedXML = "<xml></xml>";
-    mockWrapCallback.mockImplementation(callback => {
+    mockWrapCallback.mockImplementation((callback) => {
       callback(null, expectedXML);
     });
     const customSamlClient = new CustomSamlClient(
       { validateInResponseTo: true },
-      redisCacheProvider
+      redisCacheProvider,
+      undefined
     );
     customSamlClient.generateAuthorizeRequest(req, false, true, mockCallback);
     expect(mockCallback).toBeCalledWith(null, expectedXML);
   });
 
   it("should generateAuthorizeRequest save the SAML Request if tamperAuthorizeRequest is not provided", async () => {
-    const mockAuthReqTampener = jest.fn().mockImplementation(xml => {
+    const mockAuthReqTampener = jest.fn().mockImplementation((xml) => {
       return fromEither(right(xml));
     });
-    mockWrapCallback.mockImplementation(callback => {
+    mockWrapCallback.mockImplementation((callback) => {
       callback(null, SAMLRequest);
     });
     const req = mockReq();
@@ -309,15 +318,16 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
         entryPoint: "https://localhost:3000/acs",
         idpIssuer: "https://localhost:8080",
         issuer: "https://localhost:3000",
-        validateInResponseTo: true
+        validateInResponseTo: true,
       },
       redisCacheProvider,
+      undefined,
       mockAuthReqTampener
     );
     customSamlClient.generateAuthorizeRequest(req, false, true, mockCallback);
     expect(mockAuthReqTampener).toBeCalledWith(SAMLRequest, undefined);
     // Before checking the execution of the callback we must await that the TaskEither execution is completed.
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         expect(mockSet).toBeCalled();
         expect(mockCallback).toBeCalledWith(null, SAMLRequest);
@@ -327,10 +337,10 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
   });
 
   it("should call tamperAuthorizeRequest with lollipop params if client send lollipop headers", async () => {
-    const mockAuthReqTampener = jest.fn().mockImplementation(_ => {
+    const mockAuthReqTampener = jest.fn().mockImplementation((_) => {
       return fromEither(right(SAMLRequest));
     });
-    mockWrapCallback.mockImplementation(callback => {
+    mockWrapCallback.mockImplementation((callback) => {
       callback(null, SAMLRequest);
     });
     mockSet.mockImplementation((_, __, ___) => Promise.resolve("OK"));
@@ -339,9 +349,10 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
         entryPoint: "https://localhost:3000/acs",
         idpIssuer: "https://localhost:8080",
         issuer: "https://localhost:3000",
-        validateInResponseTo: true
+        validateInResponseTo: true,
       },
       redisCacheProvider,
+      undefined,
       mockAuthReqTampener
     );
 
@@ -356,10 +367,10 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
       mockCallback
     );
     expect(mockAuthReqTampener).toBeCalledWith(SAMLRequest, {
-      pubKey: aJwkPubKey
+      pubKey: aJwkPubKey,
     });
     // Before checking the execution of the callback we must await that the TaskEither execution is completed.
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         expect(mockSet).toBeCalled();
         expect(mockCallback).toBeCalledWith(null, SAMLRequest);
@@ -377,7 +388,7 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
     const lollipopSamlRequest = samlRequestWithID(
       `${DEFAULT_LOLLIPOP_HASH_ALGORITHM}-${jwkThumbprint}`
     );
-    mockWrapCallback.mockImplementation(callback => {
+    mockWrapCallback.mockImplementation((callback) => {
       callback(null, samlRequest);
     });
     mockSet.mockImplementation((_, __, ___) => Promise.resolve("OK"));
@@ -386,9 +397,10 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
         entryPoint: "https://localhost:3000/acs",
         idpIssuer: "https://localhost:8080",
         issuer: "https://localhost:3000",
-        validateInResponseTo: true
+        validateInResponseTo: true,
       },
       redisCacheProvider,
+      undefined,
       authReqTamperer
     );
 
@@ -405,7 +417,7 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
 
     const expectedSamlRequest = await pipe(
       authReqTamperer(lollipopSamlRequest, {
-        pubKey: aJwkPubKey
+        pubKey: aJwkPubKey,
       }),
       TE.mapLeft(() => fail("Cannot tamper saml request")),
       TE.toUnion
@@ -416,7 +428,7 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
     );
 
     // Before checking the execution of the callback we must await that the TaskEither execution is completed.
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         expect(mockSet).toBeCalled();
         expect(mockCallback).toBeCalledWith(null, expectedSamlRequest);
@@ -430,10 +442,10 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
 
   it("should generateAuthorizeRequest return an error if tamperAuthorizeRequest fail", async () => {
     const expectedTamperError = new Error("tamperAuthorizeRequest Error");
-    const mockAuthReqTampener = jest.fn().mockImplementation(_ => {
+    const mockAuthReqTampener = jest.fn().mockImplementation((_) => {
       return fromEither(left(expectedTamperError));
     });
-    mockWrapCallback.mockImplementation(callback => {
+    mockWrapCallback.mockImplementation((callback) => {
       callback(null, SAMLRequest);
     });
     const req = mockReq();
@@ -443,15 +455,16 @@ describe("CustomSamlClient#generateAuthorizeRequest", () => {
         entryPoint: "https://localhost:3000/acs",
         idpIssuer: "https://localhost:8080",
         issuer: "https://localhost:3000",
-        validateInResponseTo: true
+        validateInResponseTo: true,
       },
       redisCacheProvider,
+      undefined,
       mockAuthReqTampener
     );
     customSamlClient.generateAuthorizeRequest(req, false, true, mockCallback);
     expect(mockAuthReqTampener).toBeCalledWith(SAMLRequest, undefined);
     // Before checking the execution of the callback we must await that the TaskEither execution is completed.
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         expect(mockSet).not.toBeCalled();
         expect(mockCallback).toBeCalledWith(expectedTamperError);

--- a/src/strategy/__tests__/saml_client.test.ts
+++ b/src/strategy/__tests__/saml_client.test.ts
@@ -23,6 +23,7 @@ import * as TE from "fp-ts/lib/TaskEither";
 import * as E from "fp-ts/Either";
 import { RedisClientType } from "@redis/client";
 import { SamlConfig } from "../..";
+import { expectedExtraParams } from "../../__mocks__/extraParams";
 
 const expectedRequestID = "123456";
 const SAMLRequest = `<?xml version="1.0"?>
@@ -37,8 +38,6 @@ const SAMLRequest = `<?xml version="1.0"?>
   <saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">https://www.spid.gov.it/SpidL2</saml:AuthnContextClassRef>
   </samlp:RequestedAuthnContext>
 </samlp:AuthnRequest>`;
-
-const expectedExtraParams = { aNewParam: "a new param", anotherParam: 2 };
 
 const samlConfig: SamlConfig = {
   idpIssuer: "http://localhost:8080/",

--- a/src/strategy/redis_cache_provider.ts
+++ b/src/strategy/redis_cache_provider.ts
@@ -57,12 +57,12 @@ export const noopCacheProvider = (): CacheProvider => ({
 });
 
 export const getExtendedRedisCacheProvider = <
-  T extends Record<string, unknown>
+  T extends Record<string, unknown> = Record<string, never>
 >(
   redisClient: redis.RedisClientType | redis.RedisClusterType,
+  extraLoginRequestParamsCodec?: t.Type<T, T, unknown>,
   // 1 hour by default
   keyExpirationPeriodSeconds: Second = 3600 as Second,
-  extraLoginRequestParamsCodec?: t.Type<T, T, unknown>,
   keyPrefix: string = "SAML-EXT-"
 ): IExtendedCacheProvider<T> => ({
   get: (

--- a/src/strategy/redis_cache_provider.ts
+++ b/src/strategy/redis_cache_provider.ts
@@ -18,14 +18,15 @@ const SAMLRequestCacheItem = t.interface({
   idpIssuer: t.string,
 });
 
-export interface IExtendedCacheProvider {
+export interface IExtendedCacheProvider<T extends Record<string, unknown>> {
   readonly save: (
     RequestXML: string,
-    samlConfig: SamlConfig
-  ) => TaskEither<Error, SAMLRequestCacheItem>;
+    samlConfig: SamlConfig,
+    extraLoginRequestParams: T | undefined
+  ) => TaskEither<Error, SAMLRequestCacheItem | (SAMLRequestCacheItem & T)>;
   readonly get: (
     AuthnRequestID: string
-  ) => TaskEither<Error, SAMLRequestCacheItem>;
+  ) => TaskEither<Error, SAMLRequestCacheItem | (SAMLRequestCacheItem & T)>;
   readonly remove: (AuthnRequestID: string) => TaskEither<Error, string>;
 }
 
@@ -55,13 +56,18 @@ export const noopCacheProvider = (): CacheProvider => ({
   },
 });
 
-export const getExtendedRedisCacheProvider = (
+export const getExtendedRedisCacheProvider = <
+  T extends Record<string, unknown>
+>(
   redisClient: redis.RedisClientType | redis.RedisClusterType,
   // 1 hour by default
   keyExpirationPeriodSeconds: Second = 3600 as Second,
+  extraLoginRequestParamsCodec?: t.Type<T, T, unknown>,
   keyPrefix: string = "SAML-EXT-"
-): IExtendedCacheProvider => ({
-  get: (AuthnRequestID: string): TaskEither<Error, SAMLRequestCacheItem> =>
+): IExtendedCacheProvider<T> => ({
+  get: (
+    AuthnRequestID: string
+  ): TaskEither<Error, SAMLRequestCacheItem | (SAMLRequestCacheItem & T)> =>
     pipe(
       TE.tryCatch(
         () => redisClient.get(`${keyPrefix}${AuthnRequestID}`),
@@ -90,6 +96,15 @@ export const getExtendedRedisCacheProvider = (
             E.chain((_) =>
               pipe(
                 SAMLRequestCacheItem.decode(_),
+                E.map((samlRequestCacheItem) => ({
+                  ...samlRequestCacheItem,
+                  ...pipe(
+                    extraLoginRequestParamsCodec,
+                    E.fromNullable(undefined),
+                    E.chainW((codec) => codec.decode(_)),
+                    E.getOrElseW(() => ({}))
+                  ),
+                })),
                 E.mapLeft(
                   (__) =>
                     new Error(
@@ -118,8 +133,9 @@ export const getExtendedRedisCacheProvider = (
     ),
   save: (
     RequestXML: string,
-    samlConfig: SamlConfig
-  ): TaskEither<Error, SAMLRequestCacheItem> =>
+    samlConfig: SamlConfig,
+    extraLoginRequestParams: T | undefined
+  ): TaskEither<Error, SAMLRequestCacheItem | (SAMLRequestCacheItem & T)> =>
     pipe(
       TE.fromEither(
         E.fromOption(
@@ -140,7 +156,8 @@ export const getExtendedRedisCacheProvider = (
         )
       ),
       TE.chain((_) => {
-        const v: SAMLRequestCacheItem = {
+        const v: SAMLRequestCacheItem | (SAMLRequestCacheItem & T) = {
+          ...extraLoginRequestParams,
           RequestXML,
           createdAt: new Date(),
           idpIssuer: _.idpIssuer,

--- a/src/strategy/saml_client.ts
+++ b/src/strategy/saml_client.ts
@@ -82,6 +82,8 @@ export class CustomSamlClient<
                 TE.map((extraLoginRequestParams) =>
                   callback(
                     error,
+                    // Do NOT change `extraLoginRequestParams` name, unless you change the one
+                    // used in `withSpidAuthMiddleware` accordingly
                     user ? { ...user, extraLoginRequestParams } : user,
                     ___
                   )
@@ -89,7 +91,6 @@ export class CustomSamlClient<
                 TE.mapLeft(callback)
               )();
             } else {
-              // TODO: Remove from cache if AuthnRequestID exists
               callback(error, user, ___);
             }
           });

--- a/src/strategy/spid.ts
+++ b/src/strategy/spid.ts
@@ -75,8 +75,8 @@ export class SpidStrategy<
     // use our custom cache provider
     this.extendedRedisCacheProvider = getExtendedRedisCacheProvider(
       this.redisClient,
-      Math.floor(options.requestIdExpirationPeriodMs / 1000) as Second,
-      this.extraLoginRequestParamConfig?.codec
+      this.extraLoginRequestParamConfig?.codec,
+      Math.floor(options.requestIdExpirationPeriodMs / 1000) as Second
     );
 
     // bypass passport-saml cache provider

--- a/src/strategy/spid.ts
+++ b/src/strategy/spid.ts
@@ -15,7 +15,7 @@ import { MultiSamlConfig } from "passport-saml/multiSamlStrategy";
 
 import { Second } from "@pagopa/ts-commons/lib/units";
 import { pipe } from "fp-ts/lib/function";
-import { DoneCallbackT } from "..";
+import { DoneCallbackT, IExtraLoginRequestParamConfig } from "..";
 import { ILollipopParams } from "../types/lollipop";
 import {
   getExtendedRedisCacheProvider,
@@ -35,10 +35,10 @@ export type PreValidateResponseDoneCallbackT = (
   response: string
 ) => void;
 
-export type PreValidateResponseT = (
+export type PreValidateResponseT = <T extends Record<string, unknown>>(
   samlConfig: SamlConfig,
   body: unknown,
-  extendedRedisCacheProvider: IExtendedCacheProvider,
+  extendedRedisCacheProvider: IExtendedCacheProvider<T>,
   doneCb: PreValidateResponseDoneCallbackT | undefined,
 
   callback: (
@@ -49,8 +49,10 @@ export type PreValidateResponseT = (
   ) => void
 ) => void;
 
-export class SpidStrategy extends SamlStrategy {
-  private readonly extendedRedisCacheProvider: IExtendedCacheProvider;
+export class SpidStrategy<
+  T extends Record<string, unknown>
+> extends SamlStrategy {
+  private readonly extendedRedisCacheProvider: IExtendedCacheProvider<T>;
 
   // eslint-disable-next-line max-params
   constructor(
@@ -61,7 +63,8 @@ export class SpidStrategy extends SamlStrategy {
     private readonly tamperAuthorizeRequest?: XmlAuthorizeTamperer,
     private readonly tamperMetadata?: XmlTamperer,
     private readonly preValidateResponse?: PreValidateResponseT,
-    private readonly doneCb?: DoneCallbackT
+    private readonly doneCb?: DoneCallbackT,
+    private readonly extraLoginRequestParamConfig?: IExtraLoginRequestParamConfig<T>
   ) {
     super(options, verify);
     if (!options.requestIdExpirationPeriodMs) {
@@ -72,7 +75,8 @@ export class SpidStrategy extends SamlStrategy {
     // use our custom cache provider
     this.extendedRedisCacheProvider = getExtendedRedisCacheProvider(
       this.redisClient,
-      Math.floor(options.requestIdExpirationPeriodMs / 1000) as Second
+      Math.floor(options.requestIdExpirationPeriodMs / 1000) as Second,
+      this.extraLoginRequestParamConfig?.codec
     );
 
     // bypass passport-saml cache provider
@@ -93,6 +97,7 @@ export class SpidStrategy extends SamlStrategy {
           ...samlOptions,
         },
         this.extendedRedisCacheProvider,
+        this.extraLoginRequestParamConfig?.requestMapper,
         this.tamperAuthorizeRequest,
         this.preValidateResponse,
         (...args) => (this.doneCb ? this.doneCb(req.ip, ...args) : undefined)

--- a/src/utils/middleware.ts
+++ b/src/utils/middleware.ts
@@ -10,7 +10,7 @@ import * as TE from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { Profile, SamlConfig, VerifiedCallback } from "passport-saml";
 import { RedisClientType, RedisClusterType } from "redis";
-import { DoneCallbackT } from "..";
+import { DoneCallbackT, IExtraLoginRequestParamConfig } from "..";
 import { CIE_IDP_IDENTIFIERS, SPID_IDP_IDENTIFIERS } from "../config";
 import {
   PreValidateResponseT,
@@ -257,17 +257,18 @@ export const upsertSpidStrategyOption = (
 /**
  * SPID strategy factory function.
  */
-export const makeSpidStrategy = (
+export const makeSpidStrategy = <T extends Record<string, unknown>>(
   options: ISpidStrategyOptions,
-  getSamlOptions: SpidStrategy["getSamlOptions"],
+  getSamlOptions: SpidStrategy<T>["getSamlOptions"],
   redisClient: RedisClientType | RedisClusterType,
   tamperAuthorizeRequest?: XmlAuthorizeTamperer,
   tamperMetadata?: XmlTamperer,
   preValidateResponse?: PreValidateResponseT,
-  doneCb?: DoneCallbackT
-  // eslint-disable-next-line max-params
-): SpidStrategy =>
-  new SpidStrategy(
+  doneCb?: DoneCallbackT,
+  extraLoginRequestParamConfig?: IExtraLoginRequestParamConfig<T>
+): // eslint-disable-next-line max-params
+SpidStrategy<T> =>
+  new SpidStrategy<T>(
     { ...options.sp, passReqToCallback: true },
     getSamlOptions,
     (_: express.Request, profile: Profile, done: VerifiedCallback) => {
@@ -279,5 +280,6 @@ export const makeSpidStrategy = (
     tamperAuthorizeRequest,
     tamperMetadata,
     preValidateResponse,
-    doneCb
+    doneCb,
+    extraLoginRequestParamConfig
   );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- Update redis_cache_provider to store and retrieve extra parameters, if any
- Add new `IExtraLoginRequestParamConfig` for defining codec and requestMapper
- Add tests

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Enable `withSpid` to store extra parameters on Redis during login step, and return it to user-defined acs callback.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
