### PR TITLE
[#IOPID-437] Conversion EntityID commercial IdP names

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,4 +1,10 @@
-import { IDP_NAMES } from "../config";
+import { pipe } from "fp-ts/lib/function";
+import {
+  CIE_IDP_IDENTIFIERS,
+  IDP_NAMES,
+  SPID_IDP_IDENTIFIERS,
+} from "../config";
+import * as RA from "fp-ts/lib/ReadonlyArray";
 describe("IDP_NAMES", () => {
   it("should return the IdP name if a valid entityId is provided", () => {
     const aValidEntityID = "https://id.eht.eu";
@@ -10,5 +16,17 @@ describe("IDP_NAMES", () => {
     const aInvalidEntityID = "https://invalid.entity.id";
     const idpName = IDP_NAMES[aInvalidEntityID];
     expect(idpName).toBeUndefined();
+  });
+
+  it("All the possible entityId should be mapped as IdP names", () => {
+    const possibleEntityID = [
+      ...Object.keys(SPID_IDP_IDENTIFIERS),
+      ...Object.keys(CIE_IDP_IDENTIFIERS),
+    ];
+    pipe(
+      possibleEntityID,
+      RA.map((entityId) => IDP_NAMES[entityId]),
+      RA.map((entityName) => expect(entityName).toBeDefined())
+    );
   });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -2,9 +2,11 @@ import { pipe } from "fp-ts/lib/function";
 import {
   CIE_IDP_IDENTIFIERS,
   IDP_NAMES,
+  Issuer,
   SPID_IDP_IDENTIFIERS,
 } from "../config";
 import * as RA from "fp-ts/lib/ReadonlyArray";
+import * as E from "fp-ts/Either";
 describe("IDP_NAMES", () => {
   it("should return the IdP name if a valid entityId is provided", () => {
     const aValidEntityID = "https://id.eht.eu";
@@ -13,7 +15,7 @@ describe("IDP_NAMES", () => {
   });
 
   it("should return undefined if a invalid entityId is provided", () => {
-    const aInvalidEntityID = "https://invalid.entity.id";
+    const aInvalidEntityID = "https://invalid.entity.id" as Issuer;
     const idpName = IDP_NAMES[aInvalidEntityID];
     expect(idpName).toBeUndefined();
   });
@@ -22,11 +24,26 @@ describe("IDP_NAMES", () => {
     const possibleEntityID = [
       ...Object.keys(SPID_IDP_IDENTIFIERS),
       ...Object.keys(CIE_IDP_IDENTIFIERS),
-    ];
+    ] as ReadonlyArray<Issuer>;
     pipe(
       possibleEntityID,
       RA.map((entityId) => IDP_NAMES[entityId]),
       RA.map((entityName) => expect(entityName).toBeDefined())
+    );
+  });
+});
+
+describe("Issuer", () => {
+  it("Should successfully decode any possible EntityId", () => {
+    const possibleEntityID = [
+      ...Object.keys(SPID_IDP_IDENTIFIERS),
+      ...Object.keys(CIE_IDP_IDENTIFIERS),
+    ];
+    pipe(
+      possibleEntityID,
+      RA.map(Issuer.decode),
+      RA.every(E.isRight),
+      (result) => expect(result).toBeTruthy()
     );
   });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,14 @@
+import { IDP_NAMES } from "../config";
+describe("IDP_NAMES", () => {
+  it("should return the IdP name if a valid entityId is provided", () => {
+    const aValidEntityID = "https://id.eht.eu";
+    const idpName = IDP_NAMES[aValidEntityID];
+    expect(idpName).toBeDefined();
+  });
+
+  it("should return undefined if a invalid entityId is provided", () => {
+    const aInvalidEntityID = "https://invalid.entity.id";
+    const idpName = IDP_NAMES[aInvalidEntityID];
+    expect(idpName).toBeUndefined();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import * as t from "io-ts";
 /* eslint-disable @typescript-eslint/naming-convention */
 export const SPID_IDP_IDENTIFIERS = {
   "https://id.eht.eu": "ehtid",
@@ -22,7 +23,13 @@ export const CIE_IDP_IDENTIFIERS = {
     "xx_servizicie_test",
 };
 
-export const IDP_NAMES: Record<string, string | undefined> = {
+export const Issuer = t.union([
+  t.keyof(SPID_IDP_IDENTIFIERS),
+  t.keyof(CIE_IDP_IDENTIFIERS),
+]);
+export type Issuer = t.TypeOf<typeof Issuer>;
+
+export const IDP_NAMES: Record<Issuer, string | undefined> = {
   // CIE IdP
   "https://collaudo.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO":
     "CIE ID collaudo",

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,24 +22,28 @@ export const CIE_IDP_IDENTIFIERS = {
     "xx_servizicie_test",
 };
 
-export enum IDP_NAMES {
-  // SPID IdP
-  "https://id.eht.eu" = "Etna ID",
-  "https://id.lepida.it/idp/shibboleth" = "Lepida ID",
-  "https://identity.infocert.it" = "InfoCert ID",
-  "https://identity.sieltecloud.it" = "Sielte ID",
-  "https://idp.namirialtsp.com/idp" = "Namirial ID",
-  "https://login.id.tim.it/affwebservices/public/saml2sso" = "Tim ID",
-  "https://loginspid.aruba.it" = "Aruba ID",
-  "https://loginspid.infocamere.it" = "ID Infocamere",
-  "https://posteid.poste.it" = "Poste ID",
-  "https://spid.register.it" = "SpidItalia",
-  "https://spid.teamsystem.com/idp" = "TeamSystem ID",
+export const IDP_NAMES: Record<string, string | undefined> = {
   // CIE IdP
-  "https://idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO" = "CIE ID",
-  "https://collaudo.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO" = "CIE ID collaudo",
-  "https://preproduzione.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO" = "CIE ID test",
-}
+  "https://collaudo.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO":
+    "CIE ID collaudo",
+  "https://idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO":
+    "CIE ID",
+  "https://preproduzione.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO":
+    "CIE ID test",
+  // SPID IdP
+  // eslint-disable-next-line sort-keys
+  "https://id.eht.eu": "Etna ID",
+  "https://id.lepida.it/idp/shibboleth": "Lepida ID",
+  "https://identity.infocert.it": "InfoCert ID",
+  "https://identity.sieltecloud.it": "Sielte ID",
+  "https://idp.namirialtsp.com/idp": "Namirial ID",
+  "https://login.id.tim.it/affwebservices/public/saml2sso": "Tim ID",
+  "https://loginspid.aruba.it": "Aruba ID",
+  "https://loginspid.infocamere.it": "ID Infocamere",
+  "https://posteid.poste.it": "Poste ID",
+  "https://spid.register.it": "SpidItalia",
+  "https://spid.teamsystem.com/idp": "TeamSystem ID",
+};
 
 /*
  * @see https://www.agid.gov.it/sites/default/files/repository_files/regole_tecniche/tabella_attributi_idp.pdf

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,25 @@ export const CIE_IDP_IDENTIFIERS = {
     "xx_servizicie_test",
 };
 
+export enum IDP_NAMES {
+  // SPID IdP
+  "https://id.eht.eu" = "Etna ID",
+  "https://id.lepida.it/idp/shibboleth" = "Lepida ID",
+  "https://identity.infocert.it" = "InfoCert ID",
+  "https://identity.sieltecloud.it" = "Sielte ID",
+  "https://idp.namirialtsp.com/idp" = "Namirial ID",
+  "https://login.id.tim.it/affwebservices/public/saml2sso" = "Tim ID",
+  "https://loginspid.aruba.it" = "Aruba ID",
+  "https://loginspid.infocamere.it" = "ID Infocamere",
+  "https://posteid.poste.it" = "Poste ID",
+  "https://spid.register.it" = "SpidItalia",
+  "https://spid.teamsystem.com/idp" = "TeamSystem ID",
+  // CIE IdP
+  "https://idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO" = "CIE ID",
+  "https://collaudo.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO" = "CIE ID collaudo",
+  "https://preproduzione.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO" = "CIE ID test",
+}
+
 /*
  * @see https://www.agid.gov.it/sites/default/files/repository_files/regole_tecniche/tabella_attributi_idp.pdf
  */


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add a new enum to map `entityId` to the IdP commercial name.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The notification email sent to the user at the login need to include a readable information about what IdP was used to complete the login.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
