### PR TITLE
[#IOPID-1612, #IOPID-1513] SAMLResponse missing errorMessage

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -278,9 +278,10 @@ describe("Custom errors", () => {
   });
 
   it.each`
-    title          | SAMLResponse
-    ${"undefined"} | ${undefined}
-    ${"null"}      | ${null}
+    title             | SAMLResponse
+    ${"undefined"}    | ${undefined}
+    ${"null"}         | ${null}
+    ${"empty string"} | ${""}
   `(
     "during acs it should redirect to error if SAMLResponse is $title",
     async ({ SAMLResponse }) => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -9,17 +9,18 @@ import {
   IApplicationConfig,
   IServiceProviderConfig,
   SamlConfig,
-  withSpid
+  withSpid,
 } from "../";
 import { IDPEntityDescriptor } from "../types/IDPEntityDescriptor";
 import * as metadata from "../utils/metadata";
 import { getSpidStrategyOption } from "../utils/middleware";
+import { ERROR_SAML_RESPONSE_MISSING } from "../utils/samlUtils";
 
 import {
   mockCIEIdpMetadata,
   mockCIETestIdpMetadata,
   mockIdpMetadata,
-  mockTestenvIdpMetadata
+  mockTestenvIdpMetadata,
 } from "../__mocks__/metadata";
 
 const mockFetchIdpsMetadata = jest.spyOn(metadata, "fetchIdpsMetadata");
@@ -100,7 +101,7 @@ const appConfig: IApplicationConfig = {
   loginPath: expectedLoginPath,
   metadataPath,
   sloPath: expectedSloPath,
-  spidLevelsWhitelist: ["SpidL2", "SpidL3"]
+  spidLevelsWhitelist: ["SpidL2", "SpidL3"],
 };
 
 const samlConfig: SamlConfig = {
@@ -114,7 +115,7 @@ const samlConfig: SamlConfig = {
   issuer: "https://spid.agid.gov.it/cd",
   logoutCallbackUrl: "http://localhost:3000/slo",
   privateCert: samlKey,
-  validateInResponseTo: true
+  validateInResponseTo: true,
 };
 
 const serviceProviderConfig: IServiceProviderConfig = {
@@ -122,7 +123,7 @@ const serviceProviderConfig: IServiceProviderConfig = {
   organization: {
     URL: "https://example.com",
     displayName: "Organization display name",
-    name: "Organization name"
+    name: "Organization name",
   },
   publicCert: samlCert,
   requiredAttributes: {
@@ -132,16 +133,16 @@ const serviceProviderConfig: IServiceProviderConfig = {
       "name",
       "familyName",
       "fiscalNumber",
-      "mobilePhone"
+      "mobilePhone",
     ],
-    name: "Required attrs"
+    name: "Required attrs",
   },
   spidCieUrl,
   spidCieTestUrl,
   spidTestEnvUrl,
   strictResponseValidation: {
-    "http://localhost:8080": true
-  }
+    "http://localhost:8080": true,
+  },
 };
 
 const mockRedisClient = {} as RedisClientType;
@@ -186,7 +187,7 @@ describe("io-spid-commons withSpid", () => {
       acs: async () =>
         ResponsePermanentRedirect({ href: "/success?acs" } as ValidUrl),
       logout: async () =>
-        ResponsePermanentRedirect({ href: "/success?logout" } as ValidUrl)
+        ResponsePermanentRedirect({ href: "/success?logout" } as ValidUrl),
     })();
     expect(mockFetchIdpsMetadata).toBeCalledTimes(4);
     const emptySpidStrategyOption = getSpidStrategyOption(spid.app);
@@ -221,7 +222,7 @@ describe("io-spid-commons withSpid", () => {
       ...mockIdpMetadata,
       ...mockCIEIdpMetadata,
       ...mockCIETestIdpMetadata,
-      ...mockTestenvIdpMetadata
+      ...mockTestenvIdpMetadata,
     });
   });
   it("should reject blacklisted spid levels", async () => {
@@ -236,10 +237,54 @@ describe("io-spid-commons withSpid", () => {
       acs: async () =>
         ResponsePermanentRedirect({ href: "/success?acs" } as ValidUrl),
       logout: async () =>
-        ResponsePermanentRedirect({ href: "/success?logout" } as ValidUrl)
+        ResponsePermanentRedirect({ href: "/success?logout" } as ValidUrl),
     })();
     return request(spid.app)
       .get(`${appConfig.loginPath}?authLevel=SpidL1`)
       .expect(400);
   });
+});
+
+describe("Custom errors", () => {
+  beforeEach(() => {
+    initMockFetchIDPMetadata();
+  });
+
+  it.each`
+    title          | SAMLResponse
+    ${"undefined"} | ${undefined}
+    ${"null"}      | ${null}
+  `(
+    "during acs it should redirect to error if SAMLResponse is $title",
+    async ({ SAMLResponse }) => {
+      const app = express();
+      // needed to let app parse json body
+      app.use(express.json());
+      const spid = await withSpid({
+        appConfig,
+        samlConfig,
+        serviceProviderConfig,
+        redisClient: mockRedisClient as any,
+        app,
+        acs: async () =>
+          ResponsePermanentRedirect({ href: "/success?acs" } as ValidUrl),
+        logout: async () =>
+          ResponsePermanentRedirect({ href: "/success?logout" } as ValidUrl),
+      })();
+      const result = await request(spid.app)
+        .post(`${appConfig.assertionConsumerServicePath}`)
+        .set("Content-Type", "application/json")
+        .send({
+          SAMLResponse,
+        })
+        .expect(302);
+
+      if (result.error !== false) fail();
+      expect(result.headers.location).toEqual(
+        expect.stringContaining(
+          `errorMessage=${encodeURI(ERROR_SAML_RESPONSE_MISSING)}`
+        )
+      );
+    }
+  );
 });

--- a/src/utils/samlUtils.ts
+++ b/src/utils/samlUtils.ts
@@ -918,8 +918,6 @@ const notOnOrAfterValidation =
 
 export const assertionValidation =
   // eslint-disable-next-line max-lines-per-function, prettier/prettier
-
-
     (validationTimestamp: number) =>
     // eslint-disable-next-line max-lines-per-function
     (

--- a/src/utils/samlUtils.ts
+++ b/src/utils/samlUtils.ts
@@ -80,6 +80,7 @@ const cleanCert = (cert: string): string =>
     .replace(/-+END CERTIFICATE-+\r?\n?/, "")
     .replace(/\r\n/g, "\n");
 
+export const ERROR_SAML_RESPONSE_MISSING = "Missing SAMLResponse in ACS";
 const SAMLResponse = t.type({
   SAMLResponse: t.string,
 });
@@ -917,6 +918,8 @@ const notOnOrAfterValidation =
 
 export const assertionValidation =
   // eslint-disable-next-line max-lines-per-function, prettier/prettier
+
+
     (validationTimestamp: number) =>
     // eslint-disable-next-line max-lines-per-function
     (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* custom `errorMessage` in case SAMLResponse is missing

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At the moment, the error for a SAMLResponse missing is misleading and it cames from the `passport-saml` library that tries to construct an AuthNRequest if it doesn't find a proper SAMLResponse in body. This change will prevent that scenario to happen, returning a proper errorMessage so it can be tracked in our dashboards.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit tests, integration test via io-mock on io-backend

on `io-backend@13.34.2` with this `io-spid-commons` build injected:
```bash
curl --insecure -X POST https://localhost:8000/assertionConsumerService

## Found. Redirecting to https://localhost:8000/error.html?errorMessage=Missing%20SAMLResponse%20in%20ACS
```

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
